### PR TITLE
Fix 403 when downloading: Incorrect string slicing

### DIFF
--- a/photoprism/Session.py
+++ b/photoprism/Session.py
@@ -36,7 +36,7 @@ class Session():
         s = r_session()
 
         url = f"{self.url}{endpoint}"
-        if endpoint[:3] == "/dl":
+        if endpoint[-3:] == "/dl":
             url = f"{self.url}{endpoint}?t={self.download_token}"
 
         r = r_request(method=method, url=url)


### PR DESCRIPTION
The fix for https://github.com/mvlnetdev/photoprism_client/issues/8 used the wrong string slicing, leading to it not actually fixing the issue. The conditional at line 39 would never get triggered, so the `download_token` won't be passed to the request.

Example of change with test string:
```python3
endpoint_example_string = "albums/ask1kblkcktmxw9a/dl"

# Existing slice
print(endpoint_example_string[:3])

# Proposal (fixed)
print(endpoint_example_string[-3:])
```
 
Output:
```
# Existing
alb

# Corrected
/dl
```

Please merge this before tagging a new release since the code currently in the main branch still has broken downloading. Thank you.